### PR TITLE
Fixed "Listing the contents of a bucket" sample usage code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,9 @@ Listing the contents of a bucket:
 ``` scala
 val result = bucket.list
 
-result.map {
-  case l: List[BucketItem] => {
-    l.map {
-      case BucketItem(name, isVirtual) => //...
-    }
+result.map { items =>
+  items.map {
+    case BucketItem(name, isVirtual) => //...
   }
 }
 


### PR DESCRIPTION
The `Listing the contents of a bucket` sample Usage code within the `Readme` was incorrect.
