### PR TITLE
Set Content-Type for multi-part uploads

### DIFF
--- a/app/fly/play/s3/S3.scala
+++ b/app/fly/play/s3/S3.scala
@@ -209,6 +209,8 @@ class S3(val https: Boolean, val host: String)(implicit val credentials: AwsCred
 
     val acl = bucketFile.acl getOrElse PUBLIC_READ
 
+    implicit val fileContentType = ContentTypeOf[String](Some(bucketFile.contentType))
+
     val headers = (bucketFile.headers getOrElse Map.empty).toList
 
     awsWithSigner


### PR DESCRIPTION
Content-type is not set correctly for multipart uploads.
