### PR TITLE
Implemented config parameter for path style access - supersedes pull request #37

### DIFF
--- a/src/main/java/fly/play/s3/S3.scala
+++ b/src/main/java/fly/play/s3/S3.scala
@@ -34,14 +34,14 @@ object S3 {
 
   def https = config getBoolean "s3.https" getOrElse false
 
-  def bucketInHostname = config getBoolean "s3.bucketInHostname" getOrElse true
+  def pathStyleAccess = config getBoolean "s3.pathStyleAccess" getOrElse false
 
   def host = config getString "s3.host" getOrElse regionEndpoints(region)
 
   def region = config getString "s3.region" getOrElse "us-east-1"
 
   def fromConfig(implicit credentials: AwsCredentials) =
-    new S3(https, host, region, bucketInHostname)
+    new S3(https, host, region, pathStyleAccess)
 
   /**
    * Utility method to create a bucket.
@@ -67,7 +67,7 @@ object S3 {
 
 }
 
-class S3(val https: Boolean, val host: String, val region: String, val bucketInHostname: Boolean = true)(implicit val credentials: AwsCredentials) {
+class S3(val https: Boolean, val host: String, val region: String, val pathStyleAccess: Boolean = false)(implicit val credentials: AwsCredentials) {
 
   lazy val signer = new S3Signer(credentials, region)
   lazy val awsWithSigner = Aws withSigner signer
@@ -87,11 +87,11 @@ class S3(val https: Boolean, val host: String, val region: String, val bucketInH
   def getBucket(bucketName: String, delimiter: String): Bucket =
     Bucket(bucketName, Some(delimiter), this)
 
-  protected def httpUrl(bucketName: String, path: String) = {
+  protected[s3] def httpUrl(bucketName: String, path: String) = {
     val protocol = if (https) "https" else "http"
 
-    if (bucketInHostname) s"$protocol://$bucketName.$host/$path"
-    else s"$protocol://$host/$bucketName/$path"
+    if (pathStyleAccess) s"$protocol://$host/$bucketName/$path"
+    else s"$protocol://$bucketName.$host/$path"
   }
 
   /**

--- a/src/test/java/fly/play/s3/S3ConfigSpec.scala
+++ b/src/test/java/fly/play/s3/S3ConfigSpec.scala
@@ -1,0 +1,85 @@
+package fly.play.s3
+
+import fly.play.aws.auth.SimpleAwsCredentials
+import play.api.test.Helpers.running
+import play.api.Play.current
+
+class S3ConfigSpec extends S3SpecSetup {
+  "S3" should {
+
+    "have the correct default value for host" inApp {
+      running(fakeApplication(Map("s3.host" -> null, "s3.region" -> null))) {
+        s3WithCredentials.host === "s3.amazonaws.com"
+      }
+    }
+
+    "have the correct default value for https" inApp {
+      s3WithCredentials.https === false
+    }
+
+    "have the correct default value for region" inApp {
+      running(fakeApplication(Map("s3.region" -> null))) {
+        s3WithCredentials.region === "us-east-1"
+      }
+    }
+
+    "get the correct value for host from the configuration" in {
+      running(fakeApplication(Map("s3.host" -> "testHost"))) {
+        s3WithCredentials.host === "testHost"
+      }
+    }
+
+    "get the correct value for https from the configuration" in {
+      running(fakeApplication(Map("s3.https" -> true))) {
+        s3WithCredentials.https === true
+      }
+    }
+
+    "get the correct default value for region from the configuration" inApp {
+      running(fakeApplication(Map("s3.region" -> "eu-west-1"))) {
+        s3WithCredentials.region === "eu-west-1"
+      }
+    }
+
+    "get the correct default value for host if region is set" inApp {
+      running(fakeApplication(Map("s3.region" -> "eu-west-1", "s3.host" -> null))) {
+        s3WithCredentials.host === "s3-eu-west-1.amazonaws.com"
+      }
+    }
+
+    "have the correct default value for pathStyleAccess " inApp {
+      s3WithCredentials.pathStyleAccess === false
+    }
+
+    "build a url with the bucket name as part of the host name when pathStyleAccess is false" in {
+      s3WithCredentials.url("test.bucket", "test") === "http://test.bucket.s3.amazonaws.com/test"
+    }
+
+    "build a url with the bucket name as part of the path when pathStyleAccess is true" in {
+      running(fakeApplication(Map("s3.pathStyleAccess" -> true))) {
+        s3WithCredentials.url("test.bucket", "test") === "http://s3.amazonaws.com/test.bucket/test"
+      }
+    }
+
+    "return an instance of bucket" inApp {
+      S3(testBucketName) must beAnInstanceOf[Bucket]
+    }
+
+    "return an instance of bucket with different credentials" inApp {
+      implicit val awsCredentials = SimpleAwsCredentials("test", "test")
+      val bucket = S3(testBucketName)
+
+      bucket.s3.credentials must_== awsCredentials
+    }
+
+    "create the correct url" inApp {
+      implicit val credentials = SimpleAwsCredentials("test", "test")
+      val url = S3.url(testBucketName, "privateREADME.txt", 1234)
+      val host = S3.host
+
+      url must startWith(s"http://$testBucketName.$host/privateREADME.txt")
+      url must contain("Expires=1234")
+    }
+
+  }
+}

--- a/src/test/java/fly/play/s3/S3SpecSetup.scala
+++ b/src/test/java/fly/play/s3/S3SpecSetup.scala
@@ -1,0 +1,37 @@
+package fly.play.s3
+
+import java.io.File
+
+import scala.concurrent.{Await, Awaitable}
+import scala.concurrent.duration.DurationInt
+import org.specs2.execute.AsResult
+import org.specs2.mutable.Specification
+import org.specs2.specification.Example
+import org.specs2.time.NoTimeConversions
+import play.api.Play.current
+import play.api.test.FakeApplication
+import play.api.test.Helpers.running
+import play.api.Application
+
+trait S3SpecSetup extends Specification with NoTimeConversions {
+  def testBucketName(implicit app: Application) =
+    app.configuration.getString("testBucketName").getOrElse(sys.error("Could not find testBucketName in configuration"))
+
+  def fakeApplication(additionalConfiguration: Map[String, _ <: Any] = Map.empty) =
+    FakeApplication(new File("./src/test"), additionalConfiguration = additionalConfiguration)
+
+  implicit class InAppExample(s: String) {
+    def inApp[T: AsResult](r: => T): Example =
+      s in running(fakeApplication()) {
+        r
+      }
+  }
+
+  def s3WithCredentials = S3.fromConfig
+
+  def await[T](a: Awaitable[T]): T =
+    Await.result(a, 120.seconds)
+
+  def noException[T](a: Awaitable[T]) =
+    await(a) must not(throwA[Throwable])
+}


### PR DESCRIPTION
I've re-named the bucketInHostname parameter to pathStyleAccess. Since the first pull request I became aware that the s3 client options in the AWS java api have a parameter with this name and I wanted to make it consistent.

I've implemented some unit tests for the construction of urls using this parameter and to test that the defaults remain as they were. In the process I split the tests into config tests and bucket tests. This makes it easy to run the config tests without having to do all the config setup necessary for the bucket tests.

I re-based the original change onto the most recent master branch.
