### PR TITLE
Url encode filename in bucket file on s3 request

### DIFF
--- a/src/main/scala/fly/play/s3/S3Client.scala
+++ b/src/main/scala/fly/play/s3/S3Client.scala
@@ -2,8 +2,8 @@ package fly.play.s3
 
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.WSRequest
-import fly.play.aws.AwsRequestHolder
-import fly.play.aws.AwsSigner
+import fly.play.aws.{AwsRequestHolder, AwsSigner, AwsUrlEncoder}
+
 import scala.concurrent.ExecutionContext
 
 class S3Client(private val wsClient: WSClient, val signer: AwsSigner, val configuration: S3Configuration) {
@@ -17,8 +17,9 @@ class S3Client(private val wsClient: WSClient, val signer: AwsSigner, val config
     val S3Configuration(_, _, https, host, pathStyleAccess) = configuration
     val protocol = if (https) "https" else "http"
 
-    if (pathStyleAccess) s"$protocol://$host/$bucketName/$path"
-    else s"$protocol://$bucketName.$host/$path"
+    val urlEncodedPath = AwsUrlEncoder.encodePath(path)
+    if (pathStyleAccess) s"$protocol://$host/$bucketName/$urlEncodedPath"
+    else s"$protocol://$bucketName.$host/$urlEncodedPath"
   }
 }
 


### PR DESCRIPTION
I found out it is not a signer issue.
First i tried encoding the path inside the Signer, but that required me to remove the encoding on "be able to add and delete files with 'weird' names" test. This again led to a Exception because of a invalid url inside WsRequest.

This might lead to backwards compatibility issue if someone else url encode their filenames already.
I guess it is possible to check if the filename already is encoded before encoding it, but i decided to keep it simple.