### PR TITLE
Play 2.7 upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 val playVersion = "2.7.0"
+
 lazy val root = (project in file("."))
   .settings(
     name := "play-s3",
@@ -8,9 +9,11 @@ lazy val root = (project in file("."))
       "com.typesafe.play" %% "play-ws"     % playVersion % "provided",
       "com.typesafe.play" %% "play-test"   % playVersion % "test",
       "com.typesafe.play" %% "play-specs2" % playVersion % "test",
+      "org.scalatest" %% "scalatest" % "3.0.5" % "test",
       "com.typesafe.play" %% "play-ahc-ws" % playVersion % "test",
       "com.typesafe.play" %% "play-logback" % playVersion % "test",
-      "commons-codec" % "commons-codec" % "1.11" % "provided"
+      "commons-codec" % "commons-codec" % "1.11" % "provided",
+      "com.typesafe.play" % "shaded-asynchttpclient" % "2.0.1" % "provided"
     )
   )
   .settings(bintraySettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
-val playVersion = "2.6.3"
-
+val playVersion = "2.7.0"
 lazy val root = (project in file("."))
   .settings(
     name := "play-s3",
@@ -10,7 +9,8 @@ lazy val root = (project in file("."))
       "com.typesafe.play" %% "play-test"   % playVersion % "test",
       "com.typesafe.play" %% "play-specs2" % playVersion % "test",
       "com.typesafe.play" %% "play-ahc-ws" % playVersion % "test",
-      "com.typesafe.play" %% "play-logback" % playVersion % "test"
+      "com.typesafe.play" %% "play-logback" % playVersion % "test",
+      "commons-codec" % "commons-codec" % "1.11" % "provided"
     )
   )
   .settings(bintraySettings: _*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")

--- a/src/main/scala/fly/play/aws/AwsRequestHolder.scala
+++ b/src/main/scala/fly/play/aws/AwsRequestHolder.scala
@@ -145,6 +145,9 @@ case class AwsRequestHolder(wrappedRequest: WSRequest, signer: AwsSigner, implic
   def withRequestTimeout(timeout: Duration): AwsRequestHolder =
     copy(wrappedRequest = wrappedRequest withRequestTimeout timeout)
 
+  def withUrl(url: String): AwsRequestHolder =
+    copy(wrappedRequest = wrappedRequest withUrl url)
+
   private def streamingBodyNotSupported =
     sys error
       """|A streaming body in the request is currently not supported. We could

--- a/src/test/scala/fly/play/aws/Aws4SignerSpec.scala
+++ b/src/test/scala/fly/play/aws/Aws4SignerSpec.scala
@@ -154,28 +154,56 @@ object Aws4SignerSpec extends S3SpecSetup {
     "example3 PUT Object" >> {
 
       val expectedCannonicalRequest =
-        """|PUT
-           |/test%24file.text
-           |
-           |content-type:text/plain
-           |date:Fri, 24 May 2013 00:00:00 GMT
-           |host:examplebucket.s3.amazonaws.com
-           |x-amz-content-sha256:44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072
-           |x-amz-date:20130524T000000Z
-           |x-amz-storage-class:REDUCED_REDUNDANCY
-           |
-           |content-type;date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class
-           |44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072""".stripMargin
+        if (play.core.PlayVersion.current.startsWith("2.7."))
+          """|PUT
+             |/test%24file.text
+             |
+             |content-type:text/plain; charset=UTF-8
+             |date:Fri, 24 May 2013 00:00:00 GMT
+             |host:examplebucket.s3.amazonaws.com
+             |x-amz-content-sha256:44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072
+             |x-amz-date:20130524T000000Z
+             |x-amz-storage-class:REDUCED_REDUNDANCY
+             |
+             |content-type;date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class
+             |44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072""".stripMargin
+        else
+          """|PUT
+             |/test%24file.text
+             |
+             |content-type:text/plain
+             |date:Fri, 24 May 2013 00:00:00 GMT
+             |host:examplebucket.s3.amazonaws.com
+             |x-amz-content-sha256:44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072
+             |x-amz-date:20130524T000000Z
+             |x-amz-storage-class:REDUCED_REDUNDANCY
+             |
+             |content-type;date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class
+             |44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072""".stripMargin
 
       val expectedStringToSign =
-        """|AWS4-HMAC-SHA256
-           |20130524T000000Z
-           |20130524/us-east-1/s3/aws4_request
-           |0f10f84734b64a0f7ac71f28a26c6d34d07bc39df988e9e9c39bfc1fc154b6cd""".stripMargin
+        if (play.core.PlayVersion.current.startsWith("2.7."))
+          """|AWS4-HMAC-SHA256
+             |20130524T000000Z
+             |20130524/us-east-1/s3/aws4_request
+             |f8bc133040708ec4d9462312b10d102a942e6984358391d90e7df4e66d07b0e0""".stripMargin
+        else
+          """|AWS4-HMAC-SHA256
+             |20130524T000000Z
+             |20130524/us-east-1/s3/aws4_request
+             |0f10f84734b64a0f7ac71f28a26c6d34d07bc39df988e9e9c39bfc1fc154b6cd""".stripMargin
 
-      val expectedSignature = "f093977030bf8d8069918f1b3546fd02cf697d43e763c40d58c109a2e197bdac"
+      val expectedSignature =
+        if (play.core.PlayVersion.current.startsWith("2.7."))
+          "fae025cee8702959355df87bdd1215eb556e1d70417f5ce18edd46e1dab34d40"
+        else
+          "f093977030bf8d8069918f1b3546fd02cf697d43e763c40d58c109a2e197bdac"
 
-      val expectedAuthorizationHeader = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=content-type;date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class,Signature=f093977030bf8d8069918f1b3546fd02cf697d43e763c40d58c109a2e197bdac"
+      val expectedAuthorizationHeader =
+        if (play.core.PlayVersion.current.startsWith("2.7."))
+        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=content-type;date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class,Signature=fae025cee8702959355df87bdd1215eb556e1d70417f5ce18edd46e1dab34d40"
+        else
+        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=content-type;date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class,Signature=f093977030bf8d8069918f1b3546fd02cf697d43e763c40d58c109a2e197bdac"
 
       val signer = newSigner()
       val body = "Welcome to Amazon S3."

--- a/src/test/scala/fly/play/s3/S3BucketSpec.scala
+++ b/src/test/scala/fly/play/s3/S3BucketSpec.scala
@@ -17,6 +17,10 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
 class S3BucketSpec extends S3SpecSetup {
   sequential
 
@@ -73,7 +77,9 @@ class S3BucketSpec extends S3SpecSetup {
       val result = S3.fromApplication.get(testBucket.name, Some("README.txt"), None, None, None)
       val value = await(result)
 
-      value.header(CONTENT_TYPE) must_== Some("text/plain")
+      if (play.core.PlayVersion.current.startsWith("2.7."))
+        value.header(CONTENT_TYPE) must_== Some("text/plain; charset=UTF-8")
+      else value.header(CONTENT_TYPE) must_== Some("text/plain")
     }
 
     "be able to check if it exists" inApp {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "9.0.1-SNAPSHOT"
+version in ThisBuild := "9.0.1"


### PR DESCRIPTION
Due to https://github.com/AsyncHttpClient/async-http-client/issues/1578, this PR automatically detects play 2.7 and updates the content-type header with the charset attribute for the signature using the same mechanism as asynchttpclient so there are no signature mismatches when posting/putting files to S3. See also https://discuss.lightbend.com/t/aws-signature-mismatch-with-signed-payloads-after-upgrading-to-play-ahc-ws-2-7-0-play-s3/3510/4